### PR TITLE
Add featured images to generated blog posts using Pexels

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,9 +115,9 @@ myrtle config pexels
 - **API Key**: Get free from [Pexels API](https://www.pexels.com/api/)
 - **Free Tier**: 200 requests/hour, 20,000/month
 - **Benefits**:
-  - Keyword-relevant stock photos automatically added to posts
+  - Keyword-relevant featured images and inline stock photos automatically added to posts
   - Proper photographer attribution
-- **Fallback**: If not configured, posts use Lorem Picsum placeholder images
+- **Fallback**: If not configured, posts use Lorem Picsum placeholder images for featured and inline post images
 
 **Getting a Pexels API Key:**
 1. Visit [pexels.com/api](https://www.pexels.com/api/)

--- a/src/cli/commands/create.ts
+++ b/src/cli/commands/create.ts
@@ -402,13 +402,14 @@ export async function createCommand(args: string[]): Promise<void> {
           siteContext,
           title,
           currentPendingCategory.category,
-          [currentPendingCategory.category],
+          [title, currentPendingCategory.category],
           generationOptions
         );
 
         const post: PostContent = {
           title: generated.title,
           content: generated.content,
+          featureImage: generated.featureImage,
         };
 
         state = StateManager.markPostComplete(state, currentPendingCategory.category, post);

--- a/src/generators/content-generator.ts
+++ b/src/generators/content-generator.ts
@@ -30,10 +30,20 @@ export class ContentGenerator {
     options?: GenerationOptions
   ): Promise<GeneratedContent> {
     // Fetch images (will use Pexels if configured, Lorem Picsum otherwise)
-    let images: ImageResult[] | undefined;
+    let featureImage: GeneratedContent['featureImage'] | undefined;
+    let inlineImages: ImageResult[] | undefined;
+
     try {
       const searchKeywords = keywords || [category || title];
-      images = await this.imageService.getImagesForPost(searchKeywords, 2);
+      const images = await this.imageService.getImagesForPost(searchKeywords, 3);
+      featureImage = images[0]
+        ? {
+            url: images[0].url,
+            alt: images[0].alt,
+            caption: `Photo by ${images[0].photographer}`,
+          }
+        : undefined;
+      inlineImages = images.slice(1);
     } catch (error) {
       // If image fetching fails, continue without images
       console.warn('Failed to fetch images:', error);
@@ -45,7 +55,7 @@ export class ContentGenerator {
       this.provider.name,
       category,
       keywords,
-      images
+      inlineImages
     );
 
     const response = await this.provider.generate({
@@ -63,6 +73,7 @@ export class ContentGenerator {
     return {
       title,
       content,
+      featureImage,
       metadata: {
         keywords,
         wordCount,

--- a/src/ghost/ghost-client.ts
+++ b/src/ghost/ghost-client.ts
@@ -4,6 +4,7 @@ import type {
   PageContent,
   CategoryContent,
   GhostPost,
+  PostContent,
 } from '../types/index.js';
 import { GhostApiError } from '../types/index.js';
 
@@ -73,7 +74,7 @@ export class GhostClient {
    * Push a single post to Ghost
    */
   async pushPost(
-    post: { title: string; content: string },
+    post: PostContent,
     tags: string[],
     status: 'draft' | 'published' = 'published'
   ): Promise<void> {
@@ -81,6 +82,9 @@ export class GhostClient {
       const ghostPost: GhostPost = {
         title: post.title,
         html: post.content,
+        feature_image: post.featureImage?.url,
+        feature_image_alt: post.featureImage?.alt,
+        feature_image_caption: post.featureImage?.caption,
         tags: tags.map((tag) => ({
           name: tag,
           description: `Content related to ${tag}`,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -126,10 +126,17 @@ export interface ContentRequest {
   customPrompt?: string;
 }
 
+export interface FeaturedImage {
+  url: string;
+  alt: string;
+  caption?: string;
+}
+
 export interface GeneratedContent {
   title: string;
   content: string;
   excerpt?: string;
+  featureImage?: FeaturedImage;
   metadata?: {
     keywords?: string[];
     readingTime?: number;
@@ -147,6 +154,7 @@ export interface PageContent {
 export interface PostContent {
   title: string;
   content: string;
+  featureImage?: FeaturedImage;
 }
 
 export interface CategoryContent {
@@ -169,6 +177,9 @@ export interface GhostPage {
 export interface GhostPost {
   title: string;
   html: string;
+  feature_image?: string;
+  feature_image_alt?: string;
+  feature_image_caption?: string;
   tags: Array<{
     name: string;
     description?: string;

--- a/src/types/tryghost-admin-api.d.ts
+++ b/src/types/tryghost-admin-api.d.ts
@@ -14,6 +14,9 @@ declare module '@tryghost/admin-api' {
   interface PostObject {
     title: string;
     html: string;
+    feature_image?: string;
+    feature_image_alt?: string;
+    feature_image_caption?: string;
     tags?: Array<{
       name: string;
       description?: string;


### PR DESCRIPTION
## Summary

This PR uses the first fetched post image as the Ghost featured image during blog post generation and seeding.

Previously, Pexels/Lorem Picsum images were only passed into the content prompt for inline post images. Generated posts now also preserve one image as `featureImage`, and Ghost post creation sends it as:

- `feature_image`
- `feature_image_alt`
- `feature_image_caption`

## What Changed

- Added `featureImage` support to generated/stored post content
- Updated blog post generation to:
  - fetch 3 images instead of 2
  - reserve the first image as the featured image
  - pass the remaining images into the post body prompt
- Updated the Ghost post payload to include featured image fields
- Extended local `@tryghost/admin-api` typings for featured image fields
- Updated README wording to mention featured images in the Pexels section

## Behavior

- When Pexels is configured:
  - each generated post gets a keyword-relevant featured image
  - remaining fetched images are used inline in the article body
- When Pexels is not configured:
  - featured and inline post images fall back to deterministic Lorem Picsum URLs
- Existing post generation and Ghost publishing behavior remain unchanged when no featured image is available

## Verification

Tested locally with Node 22:

```bash
fnm exec --using v22.22.2 npx tsc --noEmit
fnm exec --using v22.22.2 npm run build
