### PR TITLE
Prep package for npm publish (v2.0.0)

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Jannis Fedoruk-Betschki
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/package.json
+++ b/package.json
@@ -14,6 +14,12 @@
   "bin": {
     "myrtle": "./dist/cli/index.js"
   },
+  "files": [
+    "dist",
+    "README.md",
+    "CHANGELOG.md",
+    "LICENSE"
+  ],
   "keywords": [
     "Ghost",
     "Ghost CMS",


### PR DESCRIPTION
## Summary

Closes #5.

`ghost-myrtle@2.0.0` exists in this repo (TypeScript rewrite, multi-provider AI, Pexels integration, resume, etc.) but has never been published to npm — `npm i -g ghost-myrtle` still installs `1.0.1`, whose CLI doesn't have any of the commands documented in the README.

This PR makes the package publishable as v2.0.0:

- **Add `files` allowlist to `package.json`.** Without it, npm falls back to `.gitignore` (which excludes `/dist`), so today's `npm publish` would ship a tarball without the compiled CLI that `bin` points at. Allowlist: `dist`, `README.md`, `CHANGELOG.md`, `LICENSE`.
- **Add `LICENSE`.** `package.json` declares MIT and the README links to `LICENSE`, but the file was missing from the repo.

No source / runtime changes.

## Verification

- `npm install` clean, `npm run build` green.
- `node dist/cli/index.js --help` shows the v2 command surface (`config`, `config provider <name>`, `config migrate`, `create`, `test`, `help`).
- `node dist/cli/index.js --version` prints `Ghost Myrtle v2.0.0`.
- `npm pack --dry-run` confirms the tarball includes `dist/cli/index.js`, `dist/generators/templates/styleguide-lexical.json`, `README.md`, `CHANGELOG.md`, `LICENSE` (97 files, 67.3 kB).

## Test plan

- [ ] Merge to `main`
- [ ] `npm login` (account `jannisfb`)
- [ ] `npm publish` (the `prepublishOnly` script does a clean rebuild)
- [ ] In a fresh shell: `npm i -g ghost-myrtle@latest && myrtle --version` → `Ghost Myrtle v2.0.0`
- [ ] `myrtle config pexels` opens the Pexels prompt (the exact failure from #5)
- [ ] Close #5 with a confirmation comment