### PR TITLE
Wire excerpt to Ghost custom_excerpt; declare Node engines

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,9 @@
     "typescript": "^5.7.2"
   },
   "type": "module",
+  "engines": {
+    "node": ">=22.0.0"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/betschki/ghost-myrtle"

--- a/src/cli/commands/create.ts
+++ b/src/cli/commands/create.ts
@@ -409,6 +409,7 @@ export async function createCommand(args: string[]): Promise<void> {
         const post: PostContent = {
           title: generated.title,
           content: generated.content,
+          excerpt: generated.excerpt,
           featureImage: generated.featureImage,
         };
 

--- a/src/generators/content-generator.ts
+++ b/src/generators/content-generator.ts
@@ -74,10 +74,12 @@ export class ContentGenerator {
 
     const content = this.extractContent(response.content);
     const wordCount = this.countWords(content);
+    const excerpt = this.generateExcerpt(content);
 
     return {
       title,
       content,
+      excerpt,
       featureImage,
       metadata: {
         keywords,
@@ -165,20 +167,38 @@ export class ContentGenerator {
   }
 
   /**
-   * Generate excerpt from content
+   * Generate a card-friendly excerpt from rendered HTML. Prefers the first
+   * paragraph (skipping headings, figures, blockquotes, etc.) so listings
+   * show actual prose rather than a section title.
+   *
+   * Ghost's `custom_excerpt` is capped at 300 characters, so the default
+   * stays well under that.
    */
-  generateExcerpt(html: string, maxLength: number = 160): string {
-    // Strip HTML tags
-    const text = html.replace(/<[^>]*>/g, ' ').trim();
+  generateExcerpt(html: string, maxLength: number = 200): string {
+    const firstParagraph = html.match(/<p[^>]*>([\s\S]*?)<\/p>/i)?.[1] ?? html;
+    const text = firstParagraph
+      .replace(/<[^>]*>/g, ' ')
+      .replace(/\s+/g, ' ')
+      .trim();
 
-    // Get first sentence or maxLength characters
-    const sentences = text.split(/[.!?]\s+/);
-    const firstSentence = sentences[0] || text;
-
-    if (firstSentence.length <= maxLength) {
-      return firstSentence + '.';
+    if (text.length === 0) {
+      return '';
     }
 
-    return text.substring(0, maxLength).trim() + '...';
+    // Try to break on a sentence boundary if the paragraph is long.
+    if (text.length > maxLength) {
+      const truncated = text.substring(0, maxLength);
+      const lastSentenceEnd = Math.max(
+        truncated.lastIndexOf('. '),
+        truncated.lastIndexOf('! '),
+        truncated.lastIndexOf('? ')
+      );
+      if (lastSentenceEnd > maxLength / 2) {
+        return truncated.substring(0, lastSentenceEnd + 1);
+      }
+      return truncated.trimEnd() + '…';
+    }
+
+    return text;
   }
 }

--- a/src/ghost/ghost-client.ts
+++ b/src/ghost/ghost-client.ts
@@ -82,6 +82,7 @@ export class GhostClient {
       const ghostPost: GhostPost = {
         title: post.title,
         html: post.content,
+        custom_excerpt: post.excerpt,
         feature_image: post.featureImage?.url,
         feature_image_alt: post.featureImage?.alt,
         feature_image_caption: post.featureImage?.caption,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -154,6 +154,7 @@ export interface PageContent {
 export interface PostContent {
   title: string;
   content: string;
+  excerpt?: string;
   featureImage?: FeaturedImage;
 }
 
@@ -177,6 +178,7 @@ export interface GhostPage {
 export interface GhostPost {
   title: string;
   html: string;
+  custom_excerpt?: string;
   feature_image?: string;
   feature_image_alt?: string;
   feature_image_caption?: string;

--- a/src/types/tryghost-admin-api.d.ts
+++ b/src/types/tryghost-admin-api.d.ts
@@ -14,6 +14,7 @@ declare module '@tryghost/admin-api' {
   interface PostObject {
     title: string;
     html: string;
+    custom_excerpt?: string;
     feature_image?: string;
     feature_image_alt?: string;
     feature_image_caption?: string;


### PR DESCRIPTION
## Summary

Two small things that fell out of the post-#6 review.

### Excerpts

`ContentGenerator.generateExcerpt` exists and `GeneratedContent.excerpt` is in the type, but nothing has ever called it — generated posts ship with no `custom_excerpt`, so theme card listings render whatever Ghost auto-truncates from the body HTML (often headings, attribution captions, or dropped images depending on the theme). For a tool whose whole job is producing demo content for theme showcases, that's a gap.

This PR:

- Calls `generateExcerpt(content)` from `generateBlogPost` and surfaces it on the result.
- Adds `excerpt` to `PostContent` (state-file compatible — it's optional, so existing `.myrtle-state.json` files still load).
- Forwards it to the Admin API as `custom_excerpt` in `pushPost`. Adds `custom_excerpt?: string` to both the local `GhostPost` type and the `@tryghost/admin-api` `.d.ts` stub.
- Improves the existing extractor:
  - **Prefers the first `<p>`** rather than splitting raw stripped HTML. The old version on a typical post (`<h2>Introduction</h2><p>The morning fog…</p>`) returned `"Introduction."` as the excerpt.
  - **Breaks on a sentence boundary** when truncating a long paragraph instead of mid-word with a hard `...`.
  - **Collapses multi-space whitespace** that comes from stripping adjacent block tags.
  - Bumps default budget from 160 → 200 chars (still well under Ghost's 300-char `custom_excerpt` limit).

### Engines

README requires Node 22+ but `package.json` had no `engines` field, so older-Node users got a runtime ESM crash instead of an `npm install` warning.

- Adds `"engines": { "node": ">=22.0.0" }`.

## Verification

`npm run build` clean. Smoke-tested `generateExcerpt`:

| Input | Output |
|---|---|
| `<h2>Introduction</h2><p>The morning fog rolled over the harbor…</p>` | `The morning fog rolled over the harbor…` (heading correctly skipped) |
| Long paragraph with multiple sentences | Cleanly truncated at last `.` within budget |
| `<blockquote>Just a quote.</blockquote>` (no `<p>`) | Falls back to stripped HTML |
| `''` | `''` |
| `<p>Hello   world   foo.</p>` | `Hello world foo.` (whitespace collapsed) |

`npm pack --dry-run` still produces a 67.3 kB tarball with the `engines` field present.

## Test plan

- [ ] Manual: `myrtle create` against a Pexels-configured Ghost test site, confirm post cards in theme listings show the excerpt rather than auto-truncated body
- [ ] Manual: install on Node 20 and confirm a clear `EBADENGINE` warning instead of a runtime ESM error