### PR TITLE
Release 2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,65 @@ All notable changes to Ghost Myrtle will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.0] - 2026-05-01
+
+### ✨ New Features
+
+- **Featured images on generated posts** (#6, thanks @jasonheecs): the first
+  fetched image is now used as Ghost's `feature_image` (with `feature_image_alt`
+  and `feature_image_caption`), so theme card listings, archives, and post
+  hero areas render with proper imagery instead of an empty hero. Remaining
+  images still go inline in the post body.
+- **Excerpts wired to Ghost's `custom_excerpt`** (#9): generated posts now
+  ship with a teaser-style excerpt extracted from the first paragraph, so
+  card listings show real prose instead of whatever Ghost auto-truncates from
+  the body HTML.
+
+### 🔧 Improvements
+
+- **More resilient Pexels image pipeline** (#8):
+  - Empty Pexels search results no longer produce image-less posts. The
+    image service now retries each provided keyword in turn (e.g. title,
+    then category) before falling through to Lorem Picsum.
+  - **Pexels-compliant attribution**: photo credits now link the
+    photographer's Pexels profile and pexels.com per the API guidelines.
+    Photographer display names are HTML-escaped (defense-in-depth) and
+    non-http(s) profile URLs are rejected.
+  - Lorem Picsum fallbacks no longer caption "Photo by Lorem Picsum" — the
+    figcaption is dropped entirely on the hero and inline images.
+  - Lorem Picsum fallback no longer pads with duplicate seeds, so the
+    featured image and an inline image can no longer end up identical.
+- **Improved excerpt extractor**: prefers the first `<p>` so headings like
+  `<h2>Introduction</h2>` no longer end up as the card excerpt; breaks long
+  paragraphs on a sentence boundary; collapses whitespace from adjacent
+  block tags.
+- **README**: Anthropic models section is now evergreen — model names are
+  fetched dynamically by the provider, so the docs no longer reference a
+  specific (and rapidly aging) Claude lineup.
+
+### 🔐 Security
+
+- **All 8 npm-audit advisories resolved** (#10) via lockfile-only updates
+  (1 critical, 3 high, 1 moderate, 3 low). Headline transitive bumps:
+  `axios` → 1.15.2 (resolved 7 advisories), `form-data` → 4.0.5 (critical
+  unsafe boundary generation), `jws` → 3.2.3, `follow-redirects` → 1.16.0.
+  No direct dependency changes in `package.json`.
+
+### 📦 Packaging
+
+- **`engines` field added** (#9): `"node": ">=22.0.0"`. Older Node now
+  fails loudly at `npm install` time instead of crashing at runtime on ESM.
+- **`files` allowlist + `LICENSE`** (#7): introduced as part of the v2.0.0
+  npm publish prep so the tarball actually ships `dist/`.
+
+### 🐛 Bug Fixes
+
+- Fixed v2.0.0 never being published to npm (#5, #7). Installing
+  `ghost-myrtle` from npm previously gave a v1 CLI whose commands didn't
+  match the v2 README.
+
+---
+
 ## [2.0.0] - 2025-01-12
 
 ### 🚀 Major Changes

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ myrtle config provider anthropic
 ```
 
 - **API Key**: Get from [Anthropic Console](https://console.anthropic.com/)
-- **Models**: Claude Sonnet 4.5, Opus 3, Haiku 3.5
+- **Models**: Available Claude models (Opus, Sonnet, Haiku) are fetched automatically from the API
 
 #### OpenRouter
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ghost-myrtle",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ghost-myrtle",
-      "version": "2.0.0",
+      "version": "2.1.0",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.32.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ghost-myrtle",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "A modern CLI tool to generate content for Ghost CMS using multiple AI providers (OpenAI, Anthropic, OpenRouter, Self-hosted).",
   "main": "dist/cli/index.js",
   "scripts": {

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1,8 +1,15 @@
 #!/usr/bin/env node
 
+import { readFileSync } from 'node:fs';
 import { configCommand } from './commands/config.js';
 import { createCommand } from './commands/create.js';
 import { testCommand } from './commands/test.js';
+
+// Read version from package.json so a release bump doesn't need a code change.
+// Layout (both during dev and once published): dist/cli/index.js → ../../package.json
+const pkg = JSON.parse(
+  readFileSync(new URL('../../package.json', import.meta.url), 'utf-8')
+) as { version: string };
 
 const HELP_MESSAGE = `
 🌿 Ghost Myrtle v2 - Modern AI Content Generation for Ghost CMS
@@ -79,8 +86,7 @@ async function main() {
       case '-v':
       case '--version':
       case 'version':
-        // Read version from package.json
-        console.log('Ghost Myrtle v2.0.0');
+        console.log(`Ghost Myrtle v${pkg.version}`);
         break;
 
       default:


### PR DESCRIPTION
## Summary

Release prep for `2.1.0`. Bumps the version, adds the CHANGELOG entry, and stops the `--version` output from rotting on the next bump.

### Highlights since `2.0.0`

| | What | PR |
|---|---|---|
| ✨ Feature | Featured images on generated posts (Pexels first image → Ghost `feature_image`) | #6 |
| ✨ Feature | Excerpts wired to Ghost `custom_excerpt` (real teasers in card listings instead of auto-truncated body) | #9 |
| 🔧 Improvement | Pexels image pipeline: keyword retry on empty results, compliant linked attribution, no more "Photo by Lorem Picsum" captions | #8 |
| 🔧 Improvement | Excerpt extractor prefers first `<p>` and breaks on sentence boundaries | #9 |
| 🔐 Security | All 8 npm-audit advisories resolved (1 critical, 3 high, 1 moderate, 3 low) via lockfile-only updates | #10 |
| 📦 Packaging | `engines: node >=22.0.0` declared so older Node fails at install time, not at runtime | #9 |
| 🐛 Bug | v2.0.0 finally on npm — README and CLI now match | #5, #7 |

Full notes in `CHANGELOG.md`.

## Drive-bys

- **README**: Anthropic models line was naming specific Claude versions that rot every few months. Replaced with "fetched automatically from the API" — the provider already does dynamic model discovery.
- **`--version` output**: was hardcoded `'Ghost Myrtle v2.0.0'` (with a comment saying it should read from `package.json` and not actually doing that). Now reads `pkg.version` via `readFileSync(new URL('../../package.json', import.meta.url))` so future bumps are one-line changes. Verified the relative path resolves both in dev and after `npm i -g` (`node_modules/ghost-myrtle/dist/cli/index.js` ↔ `node_modules/ghost-myrtle/package.json`).

## Verification

- `npm run build` clean
- `node dist/cli/index.js --version` → `Ghost Myrtle v2.1.0` ✓
- `npm pack --dry-run` → `ghost-myrtle-2.1.0.tgz`, includes `package.json` (always) + `dist` + `README.md` + `CHANGELOG.md` + `LICENSE`, 97 files
- `npm audit` → 0 vulnerabilities

## Test plan

- [ ] Merge
- [ ] `git tag v2.1.0 && git push --tags`
- [ ] `npm publish` from `main` (the `prepublishOnly` script does a clean rebuild)
- [ ] Fresh shell: `npm i -g ghost-myrtle@latest && myrtle --version` → `Ghost Myrtle v2.1.0`
- [ ] Smoke a real `myrtle create` against a throwaway Ghost site, confirm hero image + excerpt appear on a generated post